### PR TITLE
Create r-geos image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                 docker pull inwt/r-batch:$LABEL || echo "not available"
                 docker pull inwt/r-shiny:$LABEL || echo "not available"
                 docker pull inwt/r-model:$LABEL || echo "not available"
+                docker pull inwt/r-geos:$LABEL || echo "not available"
                 '''
                 }
             }
@@ -64,6 +65,16 @@ pipeline {
                 sh '''
                 docker build --cache-from inwt/r-model:$LABEL -t inwt/r-model:$LABEL r-model
                 docker push inwt/r-model:$LABEL
+                '''
+                }
+            }
+        }
+        stage('r-geos') {
+            steps {
+                withDockerRegistry([ credentialsId: "jenkins-docker-hub", url: "" ]) {
+                sh '''
+                docker build --cache-from inwt/r-geos:$LABEL -t inwt/r-geos:$LABEL r-geos
+                docker push inwt/r-geos:$LABEL
                 '''
                 }
             }

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ The container from this project can be found at:
 
 ## Featured images
 
-### r-ver-ubuntu (deprecated)
-
--   Based on Ubuntu
--   R in given version with fixed MRAN
--   Based on the rocker r-ver project
-
 ### r-base
 
 -   Starts from rocker/r-ver:4.1.2
@@ -33,17 +27,22 @@ The container from this project can be found at:
 -   Packages for data manipulation (data.table, dplyr, tidyr)
 -   Home-brewed and open source (dbtools, mctools)
 
+### r-geos
+
+-   Starts from r-batch
+-   Installs Linux libraries necessary for running geo/gis related operations.
+-   Adds geo/gis related packages (sf, stars, terra, etc.)
+
 ### r-shiny
 
 -   Starts from r-batch
 -   Adds shiny related packages (shiny, shinyjs, etc.)
 
-Start them using:
+### r-ver-ubuntu (deprecated)
 
-```
-docker pull inwt/r-base:3.4.4
-docker run -it inwt/r-base:3.4.4
-```
+-   Based on Ubuntu
+-   R in given version with fixed MRAN
+-   Based on the rocker r-ver project
 
 ## Why using docker
 
@@ -190,5 +189,3 @@ cd /path/to/your/package
 docker run --rm -v $PWD:/app --user `id -u`:`id -g` inwt/r-batch:3.4.4 check
 docker run --rm -v $PWD:/app --user `id -u`:`id -g` inwt/r-batch:3.5.1 check
 ```
-
-### Reports

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ The container from this project can be found at:
 -   R in given version with fixed MRAN
 -   Based on the rocker r-ver project
 
+## Simplest use of an image
+
+Example for `r-base` image:
+
+```
+docker pull inwt/r-base:3.4.4
+docker run -it inwt/r-base:3.4.4
+```
+
 ## Why using docker
 
 R is great but it lacks a deployment model. When you use Java, you have the JVM to abstract away the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The container from this project can be found at:
 
 -   Starts from r-batch
 -   Installs Linux libraries necessary for running geo/gis related operations.
--   Adds geo/gis related packages (sf, stars, terra, etc.)
+-   Adds geo/gis related r packages (sf, stars, terra, etc.)
 
 ### r-shiny
 

--- a/examples/geos/Dockerfile
+++ b/examples/geos/Dockerfile
@@ -1,0 +1,5 @@
+FROM inwt/r-geos:latest
+
+ADD . .
+
+CMD ["Rscript", "main.R"]

--- a/examples/geos/main.R
+++ b/examples/geos/main.R
@@ -1,0 +1,15 @@
+# Geo examples
+
+# Try out 2 exemplary packages:
+library(sf)
+library(terra)
+
+# sf
+nc <- st_read(system.file("shape/nc.shp", package = "sf"))
+class(nc)
+print(nc[9:15], n = 3)
+
+# terra
+f <- system.file("ex/lux.shp", package = "terra")
+p <- vect(f)
+print(p)

--- a/r-geos/Dockerfile
+++ b/r-geos/Dockerfile
@@ -1,0 +1,22 @@
+FROM inwt/r-batch:latest
+
+RUN apt-get -y update \
+   && apt-get install -y --no-install-recommends \
+   libgdal-dev \
+   libgeos-dev \
+   libproj-dev \
+   libudunits2-dev \
+   && apt-get autoremove -y \
+   && apt-get autoclean -y \
+   && rm -rf /var/lib/apt/lists/* \
+   && installPackage \
+    geojsonsf \
+    methods \
+    raster \
+    R.utils \
+    sf \
+    stars \
+    terra \
+    unix \
+   && rm -rf /tmp/downloaded_packages/*
+

--- a/r-geos/Dockerfile
+++ b/r-geos/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -y update \
    && rm -rf /var/lib/apt/lists/* \
    && installPackage \
     geojsonsf \
-    methods \
     raster \
     R.utils \
     sf \


### PR DESCRIPTION
closes #8 

- We dont need an [`aws.config`]( `https://github.com/INWTlab/r-docker/blob/latest/r-batch/aws.config) file like in the case for `r-batch` right?
- Do I need to create an example in the examples folder with a `main.R` script that includes some kind of geo operation, maybe using a function from the `sf::` package?
- I changed the ReadMe beyond `r-geos` because it looked somewhat outdated.
- [Jenkins fails ](https://inwt-vmeh2.inwt.de/jenkins/blue/organizations/jenkins/r-docker/detail/feature%2F8_rgeos_image/1/pipeline) :man_facepalming: - because of 

![image](https://user-images.githubusercontent.com/7808560/175339153-1260768d-f16c-4f24-a5a8-e12f1481237c.png)

Does that mean my feature branch has a name that cannot be handeld well by docker? Should I rename it to `feature_8_rgeos_image` so there is no `/` in the name?
