### PR TITLE
Make `4.2.1` the `latest`

### DIFF
--- a/r-base/Dockerfile
+++ b/r-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.2.0
+FROM rocker/r-ver:4.2.1
 
 WORKDIR /app
 ENV HOME /app

--- a/r-batch/Dockerfile
+++ b/r-batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM inwt/r-base:latest
+FROM inwt/r-base:4.2.1
 
 COPY aws.config /app/.aws/config
 

--- a/r-model/Dockerfile
+++ b/r-model/Dockerfile
@@ -1,4 +1,4 @@
-FROM inwt/r-batch:latest
+FROM inwt/r-batch:4.2.1
 
 RUN apt-get -y update \
    && apt-get install -y --no-install-recommends \

--- a/r-shiny/Dockerfile
+++ b/r-shiny/Dockerfile
@@ -1,4 +1,4 @@
-FROM inwt/r-batch:latest
+FROM inwt/r-batch:4.2.1
 
 EXPOSE 3838
 


### PR DESCRIPTION
At the moment, latest is `4.2.0`, the `4.2.1` brnach is ahead of branch `latest`.
